### PR TITLE
added seperator after "How to use section" and "Basic Buttons"

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
               </div> 
             </div>
           </section>
+          <hr class="secondary-hr">
           <section id="basic">
             <h1 class="section-header">
               Basic Buttons


### PR DESCRIPTION
added seperator after "How to use section" and "Basic Buttons"
issue #17 

<!-- Please describe what changes or additions this pull request pertain to -->

<!-- Specify the issue it relates to, if any --->
Issue:
