### PR TITLE
Replaced download text link with icon [Issue #88]

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,9 @@
         </div>
         <div class="buttons">
           <a href="https://raw.githubusercontent.com/shahednasser/sbuttons/master/dist/sbuttons.min.css"
-            class="download-link" target="_blank" style="vertical-align: middle;">Download</a>
+             class="download-link" target="_blank" style="text-decoration: none">
+            <i class="fas fa-file-download"></i>
+          </a>
           <a href="https://github.com/shahednasser/sbuttons" target="_blank" class="icon-link">
             <i class="fab fa-github"></i>
           </a>

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         <div class="buttons">
           <a href="https://raw.githubusercontent.com/shahednasser/sbuttons/master/dist/sbuttons.min.css"
              class="download-link" target="_blank" style="text-decoration: none">
-            <i class="fas fa-file-download"></i>
+            <i class="fas fa-download"></i>
           </a>
           <a href="https://github.com/shahednasser/sbuttons" target="_blank" class="icon-link">
             <i class="fab fa-github"></i>


### PR DESCRIPTION
Replaced "Download" in the navbar with an font awesome _fa-file-download_ icon.

Issue: #88 