### PR TITLE
fix: removed padding-left from .sidebar-toggler

### DIFF
--- a/assets/css/sidebar.css
+++ b/assets/css/sidebar.css
@@ -88,4 +88,8 @@
     top: 0;
     z-index: 100;
   }
+
+  .navbar .sidebar-toggler {
+    padding-left: 0;
+  }
 }


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/shahednasser/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Added to assets/sidebar.css (remove padding-left) :
`.navbar .sidebar-toggler {
    padding-left: 0;
  }`
<!-- Specify the issue it relates to, if any --->
Issue: #84 
