### PR TITLE
Disable text selection issue #71

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -85,6 +85,14 @@ header {
   cursor: default;
 }
 
+/* The value of 'none' is useful for static text labels in a user interface which are not meant to be selected. */
+.logo h1.noselect {
+  -webkit-user-select: none; /* Webkit Chrome / Edge / Safari / Opera */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Microsoft / IE 10+ */
+  user-select: none; /* Standard syntax. */
+}
+
 header .content {
   text-align: center;
   flex: 1;

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           <i class="fas fa-bars"></i>
         </button>
         <div class="logo">
-          <h1>sButtons</h1>
+          <h1 class="noselect">sButtons</h1>
         </div>
         <div class="buttons">
           <a class="toggle-theme" href="#toggleTheme" title="Toggle light/dark mode">
@@ -64,7 +64,7 @@
       </div>
       <div class="content">
         <div class="logo">
-          <h1>sButtons</h1>
+          <h1 class="noselect">sButtons</h1>
         </div>
         <div class="subtitle">
           Simple buttons you can use easily for your next project.


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/shahednasser/sbuttons/blob/master/CONTRIBUTING.md -->

<!-- Please describe what changes or additions this pull request pertain to -->
**Additions:**
- Disable text selection on the _.logo h1_ which is a child of _.navbar_ and _.content_
- Files modified: _index.html_ and _assets/css/index.css_
- Tested in the following browsers: Chrome 85, Firefox 80, Opera 70, Edge 85

<!-- Specify the issue it relates to, if any --->
Issue:
Relates to issue #71, **specs**:
Add a rule to .logo h1 to disable user selection. Make sure to add the changes to assets/css/index.css