### PR TITLE
Fixed Download Button on website

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -98,6 +98,24 @@ $(document).ready(function () {
     setTimeout(() => $element.tooltip("hide"), 1500);
   }
 
+  function downloadGithubCssRaw(){
+    const link = "https://raw.githubusercontent.com/shahednasser/sbuttons/master/dist/sbuttons.min.css";
+    fetch(link)
+      .then(resp => resp.blob())
+      .then(blob => {
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.style.display = 'none';
+        a.href = url;
+        a.download = "sbuttons.min.css";
+        document.body.appendChild(a);
+        a.click();
+        window.URL.revokeObjectURL(url);
+        document.body.removeChild(a);
+  })
+  .catch((err) => console.log(err));
+  }
+
   var copiedTooltipOptions = {
     title: "Copied",
     trigger: "click",
@@ -174,4 +192,6 @@ $(document).ready(function () {
   $(".toggle-theme").on("click", function () {
     toggleTheme();
   });
+
+  $("#downloadGithubRaw").on("click", downloadGithubCssRaw);
 });

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -98,22 +98,26 @@ $(document).ready(function () {
     setTimeout(() => $element.tooltip("hide"), 1500);
   }
 
-  function downloadGithubCssRaw(){
-    const link = "https://raw.githubusercontent.com/shahednasser/sbuttons/master/dist/sbuttons.min.css";
-    fetch(link)
-      .then(resp => resp.blob())
-      .then(blob => {
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.style.display = 'none';
-        a.href = url;
-        a.download = "sbuttons.min.css";
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
-  })
-  .catch((err) => console.log(err));
+  function downloadGithubCssRaw() {
+    var link = "https://raw.githubusercontent.com/shahednasser/sbuttons/master/dist/sbuttons.min.css";
+    if (window.fetch) {
+      fetch(link)
+        .then(resp => resp.blob())
+        .then(blob => {
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.style.display = 'none';
+          a.href = url;
+          a.download = "sbuttons.min.css";
+          document.body.appendChild(a);
+          a.click();
+          window.URL.revokeObjectURL(url);
+          document.body.removeChild(a);
+        })
+        .catch((err) => console.log(err));
+    } else {
+      window.location.href = link;
+    }
   }
 
   var copiedTooltipOptions = {
@@ -193,5 +197,5 @@ $(document).ready(function () {
     toggleTheme();
   });
 
-  $("#downloadGithubRaw").on("click", downloadGithubCssRaw);
+  $("#downloadGithubRawHeader, #downloadGithubRawHowTo").on("click", downloadGithubCssRaw);
 });

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           <a class="toggle-theme" href="#toggleTheme" title="Toggle light/dark mode">
             <i class="fas fa-moon"></i>
           </a>
-          <a href="#" id="downloadGithubRaw" class="download-link">
+          <a href="#" id="downloadGithubRawHeader" class="download-link">
             <i class="fas fa-download"></i>
           </a>
           <a href="https://github.com/shahednasser/sbuttons" target="_blank" class="icon-link">
@@ -86,7 +86,7 @@
             <div class="instructions">
               <div class="text">
                 You can download the CSS file
-                <a href="https://github.com/shahednasser/sbuttons/blob/master/dist/sbuttons.min.css" class="cssLink"
+                <a href="#" id="downloadGithubRawHowTo" class="download-link" class="cssLink"
                   target="blank">here</a> and then add it to your html file inbetween the tags.
               </div>
               <div class="text">

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
           <a class="toggle-theme" href="#toggleTheme" title="Toggle light/dark mode">
             <i class="fas fa-moon"></i>
           </a>
-          <a href="https://raw.githubusercontent.com/shahednasser/sbuttons/master/dist/sbuttons.min.css" class="download-link" target="_blank">
+          <a href="#" id="downloadGithubRaw" class="download-link">
             <i class="fas fa-download"></i>
           </a>
           <a href="https://github.com/shahednasser/sbuttons" target="_blank" class="icon-link">

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <div class="instructions">
               <div class="text">
                 You can download the CSS file
-                <a href="#" id="downloadGithubRawHowTo" class="download-link" class="cssLink"
+                <a href="#" id="downloadGithubRawHowTo" class="cssLink"
                   target="blank">here</a> and then add it to your html file inbetween the tags.
               </div>
               <div class="text">


### PR DESCRIPTION
The download button now download a file with all the code instead of opening the raw github page.

<a download / wasn't working as raw github page isn't considered like a file , so i came up with using JS & fetch API.

Issue: #158 
