### PR TITLE
Show loading wheel before button examples appear

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -445,3 +445,18 @@ button.clipboard:focus {
     background-position: 0% 50%;
   }
 }
+
+.loader {
+  border: 16px solid #f3f3f3; /* Light grey */
+  border-top: 16px solid #3498db; /* Blue */
+  border-radius: 50%;
+  width: 120px;
+  height: 120px;
+  animation: spin 2s linear infinite;
+  margin: auto;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/assets/js/buttons-examples.js
+++ b/assets/js/buttons-examples.js
@@ -426,9 +426,9 @@ $(document).ready(function () {
     }
     return section;
   }
-
   for (var i = 0; i < buttons.length; i++) {
     var section = createSection(buttons[i], true);
     section.appendTo(content);
   }
+  $("#loading_wheel").remove();
 });

--- a/index.html
+++ b/index.html
@@ -77,6 +77,9 @@
       <a href="getStarted.html" class="banner-link">Get Started</a>
     </div>
   </header>
+  <div class="container mt-5" id="loading_wheel">
+    <div class="loader"></div>
+  </div>
   <div class="container mt-5">
     <div class="row">
       <div class="col-md-3 d-md-block">


### PR DESCRIPTION
<!-- Please read the contribution guide before contributing https://github.com/shahednasser/sbuttons/blob/master/CONTRIBUTING.md -->
<!-- Please describe what changes or additions this pull request pertain to -->
Added a loading wheel that spins while buttons are loading and disappears they have loaded.

![loading demo gif](https://user-images.githubusercontent.com/31869974/94870625-a25caa80-040d-11eb-9351-8b89295ae488.gif)

Followed [this tutorial](https://www.w3schools.com/howto/howto_css_loader.asp) to create the wheel. 

<!-- Specify the issue it relates to, if any --->
Issue: #484 
