### PR TITLE
social block buttons moved towards login text

### DIFF
--- a/dist/sbuttons.css
+++ b/dist/sbuttons.css
@@ -1212,6 +1212,9 @@ a.yellow-btn:active:not(.fill-color-btn) {
   box-shadow: 0px 1px 7px #4d4d4d;
   transform: translateY(-3px);
 }
+.social-btn.block-btn:after {
+  margin-right: 1rem;
+}
 .social-btn.google {
   background-color: #fff;
   color: #353535;

--- a/src/components/_social.less
+++ b/src/components/_social.less
@@ -17,7 +17,11 @@
     transform: translateY(-3px);
   }
 }
-
+.social-btn.block-btn {
+  &:after {
+    margin-right: 1rem;
+  }
+}
 @import "social/_google.less";
 @import "social/_apple.less";
 @import "social/_facebook.less";


### PR DESCRIPTION
The icons of the social buttons which are also block buttons have been moved a bit left towards the "Login with.." text.

Files changed : dist/sbuttons.css and src/components/_social.less
Issue: #309 
